### PR TITLE
Build mapton with JDK 14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
                     <configuration>
-                        <release>11</release>
+                        <source>11</source>
+                        <target>11</target>
                         <showDeprecation>true</showDeprecation>
                         <compilerArgument>-Xlint:unchecked</compilerArgument>
                     </configuration>


### PR DESCRIPTION
Building mapton with JDK 14.0.1 full version (with JavaFX) 
```
openjdk version "14.0.1" 2020-04-14
OpenJDK Runtime Environment (build 14.0.1+8)
OpenJDK 64-Bit Server VM (build 14.0.1+8, mixed mode, sharing)
```
gives error:
```
> mvn package
[INFO] mapton-api ......................................... FAILURE [  3.225 s]
constituent[42]: file:/usr/share/maven/lib/maven-artifact-3.x.jar
---------------------------------------------------
Exception in thread "main" java.lang.AssertionError
    at jdk.compiler/com.sun.tools.javac.util.Assert.error(Assert.java:155)
    at jdk.compiler/com.sun.tools.javac.util.Assert.check(Assert.java:46)
    at jdk.compiler/com.sun.tools.javac.comp.Modules.enter(Modules.java:247)
...
```
The proposed change updates `<release>11</release>` option in maven-compiler-plugin to
```
    <source>11</source>
    <target>11</target>
``` 
After that I am able to build mapton with JDK 14.